### PR TITLE
Add basic steps to CircleCI SaaS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    resource_class: small
+    resource_class: large
     docker:
       - image: circleci/android:api-28
         environment:
@@ -13,7 +13,7 @@ jobs:
           name: Create folders
           command: mkdir -p /home/circleci/android/licenses
       - restore_cache:
-          key: dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
+          key: dependencies-{{ checksum "build.gradle" }}
       - run:
           name: Accept licenses
           command: cp /opt/android/sdk/licenses/* $ANDROID_HOME/licenses
@@ -21,114 +21,26 @@ jobs:
           name: Install dependencies
           command: ./gradlew dependencies
       - run:
+          name: Linter
+          command: ./gradlew lint spotlessCheck
+      - run:
           name: Run tests
           command: ./gradlew check test --profile
       - save_cache:
-          key: dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
+          key: dependencies-{{ checksum "build.gradle" }}
           paths:
             - /home/circleci/.android
             - /home/circleci/android
             - /home/circleci/.gradle
-            - /usr/local/android-sdk-linux/platforms/android-25
-            - /usr/local/android-sdk-linux/build-tools/25.0.0
+            - /usr/local/android-sdk-linux/platforms/android-28
+            - /usr/local/android-sdk-linux/build-tools/28.0.0
             - /usr/local/android-sdk-linux/extras/android/m2repository
-      - store_artifacts:
-          path: analytics-core/build/test-report
-          destination: reports
-      - store_artifacts:
-          path: analytics-integrations/*/build/test-report
-          destination: reports
-      - store_artifacts:
-          path: build/reports/profile
-          destination: reports
-      - persist_to_workspace:
-          root: .
-          paths: [.]
-
-  publish_snapshot:
-    resource_class: small
-    docker:
-      - image: circleci/android:api-25-alpha
-        environment:
-          ANDROID_HOME: /home/circleci/android
-          CIRCLE_JDK_VERSION: oraclejdk8
-
-    steps:
-      - attach_workspace: { at: . }
-      - restore_cache:
-                key: dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
-      - run:
-          name: Set up signature
-          command: |
-              if [ "$SIGNATURE_SECRET" == "" ]; then {
-                  echo "Invalid signature configuration"
-                  exit 1
-              } fi
-              base64 -d - <<< "$SIGNATURE_SECRET" > $SIGNATURE_SECRET_FILE
-              gpg --batch --yes --import $SIGNATURE_SECRET_FILE <<< $SIGNATURE_PASSWORD
-      - run:
-          name: Publish SNAPSHOT
-          command: ./gradlew uploadArchives
-
-  publish:
-      resource_class: small
-      docker:
-        - image: circleci/android:api-25-alpha
-          environment:
-            ANDROID_HOME: /home/circleci/android
-            CIRCLE_JDK_VERSION: oraclejdk8
-
-      steps:
-        - attach_workspace: { at: . }
-        - restore_cache:
-                  key: dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
-        - run:
-            name: Set up signature
-            command: |
-                if [ "$SIGNATURE_SECRET" == "" ]; then {
-                    echo "Invalid signature configuration"
-                    exit 1
-                } fi
-                base64 -d - <<< "$SIGNATURE_SECRET" > $SIGNATURE_SECRET_FILE
-                gpg --batch --yes --import $SIGNATURE_SECRET_FILE <<< $SIGNATURE_PASSWORD
-        - run:
-            name: Verify tag
-            command: |
-                VERSION=$(grep VERSION gradle.properties | awk -F= '{ print $2 }' | awk -F- '{ print $1 }')
-                if [ "$CIRCLE_TAG" != "$VERSION" ]; then {
-                    echo "Tag $CIRCLE_TAG does not match the package version ($VERSION)"
-                    exit 1
-                } fi
-        - run:
-            name: Publish new version
-            command: ./gradlew uploadArchives -Prelease
-        - run:
-            name: Mark release
-            command: ./gradlew closeAndReleaseRepository
-
 
 workflows:
   version: 2
   run:
     jobs:
       - build:
-          context: Android
-          filters:  
+          filters:
             tags: 
               only: /.*/
-      - publish_snapshot:
-          context: Android
-          requires: [ build ]
-          filters:
-            branches:
-              only: /master/
-            tags:
-              only: /.*/
-      - publish:
-          context: Android
-          requires: [ build ]
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /[0-9]+(\.[0-9]+)*(-.+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ jobs:
             - /usr/local/android-sdk-linux/platforms/android-28
             - /usr/local/android-sdk-linux/build-tools/28.0.0
             - /usr/local/android-sdk-linux/extras/android/m2repository
+      - store_artifacts:
+          path: build/reports/profile/
+          destination: reports
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Verify configuration changes (only Segment employees are allowed to do them)
+          command: |
+            set -e
+            wget -qO - https://raw.githubusercontent.com/segmentio/analytics-android-integrations/master/.circleci/config.yml | cmp - .circleci/config.yml
+      - run:
           name: Create folders
           command: mkdir -p /home/circleci/android/licenses
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -125,3 +125,16 @@ $ ./gradlew test
 #### 3 Include a well detailed title and description 
 
 ### Ready to go :rocket:
+
+## How to review a PR
+Here's a checklist of what to look for when reviewing a PR:
+- [x] No changes have been made to `.circleci`.
+- [x] No changes have been made to `.buildkite`.
+- [x] CircleCI SaaS has completed successfully.
+- [x] Buildkite CI has completed successfully (only for non-forked repos).
+- [x] There is *enough* testing coverage for the changes.
+- [x] If the change is updating an integration's SDK, the Changelog link is included in the description of the PR.
+- [x] Big changes are split on multiple commits.
+- [x] The version has changed following SemVer for functional changes.
+
+If any of this checks fail, the PR will be rejected.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Version `1.Y.0`: is the release when a backwards compatible feature is introduce
 Version `X.0.0`: is the release when a backwards incompatible change is introduced to the integration SDK. `X` must  be incremented while the `minor` and `patch` version numbers must be reset to 0. i.e  `2.0.0`
 
 ### Before Submitting a PR
+**Important** PRs from non-Segment employees that change circleci or buildkite configuration (CI) will be
+rejected automatically. Do not change the CI configuration.
 
 - [x] Run linter and formatter
 ```bash
@@ -114,7 +116,7 @@ $ ./gradlew test
 ### Before Submitting PR Requirements
 #### 1 You must run spotless for code formatting before committing
 ```
-./gradlew spotlessApply
+./gradlew lintFix spotlessApply
 ```
 #### 2 You must run the tests, ensuring they all pass
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # analytics-android-integrations
+
+[![CircleCI](https://circleci.com/gh/segmentio/analytics-android-integrations/tree/master.svg?style=svg)](https://circleci.com/gh/segmentio/analytics-android-integrations/tree/master)
+
 Monorepo storing Segment's analytics Android integrations. You can find additional documentation for this repo in the `guides` directory.
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ allprojects({ Project project ->
 
     // Configuration for integrations
     if (project.ext.isIntegration) {
+        project.ext.integrationName = project.name.substring(1)
+
         project.apply(plugin: 'com.android.library')
         project.apply(from: rootProject.file('gradle/attach-jar.gradle'))
         project.apply(from: rootProject.file('gradle/sign.gradle'))


### PR DESCRIPTION
This is for the public CircleCI instance.

**Note:** All CircleCI builds must fail from commit `ed0ad9a9e6b04965dd3c865de58b7dafe32dadb4` because is when we added the check for changes on `.circleci/config.yml`