### PR TITLE
amplitude: add string array support for some identify calls

### DIFF
--- a/integrations/amplitude/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/integrations/amplitude/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -255,6 +255,9 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       String stringValue = String.valueOf(value);
       identify.set(key, stringValue);
     }
+    if (value instanceof String[]) {
+      identify.set(key, (String[]) value);
+    }
   }
 
   @Override


### PR DESCRIPTION
This code adds support for sending string arrays to amplitude as
traits when either traitsToIncrement or traitsToSetOnce are set.

https://segment.atlassian.net/browse/LIB-1605
**What does this PR do?**
This PR adds support for string arrays in traits when either traitsToIncrement or traitsToSetOnce are set

**Are there breaking changes in this PR?**
no

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Yes


Running the current version of code I sent a request via the amplitude sdk with the userId 'dog', setting a 'dog' string array property


<img width="508" alt="Screen Shot 2020-02-28 at 11 22 29 AM" src="https://user-images.githubusercontent.com/6434313/75707599-02bb1c00-5c74-11ea-9840-69364583ced6.png">
<img width="1655" alt="Screen Shot 2020-02-28 at 11 19 24 AM" src="https://user-images.githubusercontent.com/6434313/75708071-ed92bd00-5c74-11ea-8a40-db006a7c56e0.png">

Above you can observe the absence of the property

Then I made the code change in this PR and sent another request 'zebra' with a string array property 'zebra'

<img width="508" alt="Screen Shot 2020-02-28 at 11 22 20 AM" src="https://user-images.githubusercontent.com/6434313/75707629-14042880-5c74-11ea-8d11-2f67dfd6dac3.png">
<img width="1673" alt="Screen Shot 2020-02-28 at 11 19 33 AM" src="https://user-images.githubusercontent.com/6434313/75707638-1797af80-5c74-11ea-88ea-64097bd1e25e.png">

In this screenshot below we can observe that the property 'dog' is absent whereas the property 'dog' is not

<img width="1669" alt="Screen Shot 2020-02-28 at 11 21 54 AM" src="https://user-images.githubusercontent.com/6434313/75708132-131fc680-5c75-11ea-9b34-34bca3bbf22b.png">


**Any background context you want to provide?**
This PR was prompted by the change made here by zenly in their fork 
https://github.com/znly/analytics-android-integration-amplitude/commit/45d22e851dfa0c8915fa4dd8e813e262884a7470

I tested this change using the sample app in the analytics-android repo and made some changes including importing this repo as a module, the code i tested with is represented here https://github.com/segmentio/analytics-android/commit/76b60b86dbf661baa5be34b67e1219253689ec06

**Is there parity with the server-side/analytics.js integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
no

**What are the relevant tickets?**
https://segment.atlassian.net/browse/LIB-1605

**Link to CC ticket**
CC in this PR

**List all the tests accounts you have used to make sure this change works**
My own amplitude test account

**Helpful Docs**


**Version for this change**
